### PR TITLE
Make sure when installing as root to unpack as self and not preserve own...

### DIFF
--- a/install-libxl.js
+++ b/install-libxl.js
@@ -229,7 +229,7 @@ var extractor = function(file, target, callback) {
     if (isWin) {
         execute(path.join('tools', '7zip', '7za.exe'), ['x', file, '-o' + dependencyDir], callback);
     } else {
-        execute('tar', ['-C', dependencyDir, '-zxf', file], callback);
+        execute('tar', ['-C', dependencyDir, '--no-same-owner', '-zxf', file], callback);
     }
 };
 


### PR DESCRIPTION
Fixes npm install in source tree as root within a docker builder container.
